### PR TITLE
Clean up README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 gulp-postcss
 ============
 
-[PostCSS](https://github.com/postcss/postcss) gulp plugin
+[PostCSS](https://github.com/postcss/postcss) gulp plugin to process CSS throw
+several processors, but parse CSS only once.
 
 ## Basic usage
 
-```
+```js
 var postcss = require('gulp-postcss')
 var gulp = require('gulp')
 var autoprefixer = require('autoprefixer')
@@ -13,15 +14,15 @@ var mqpacker = require('css-mqpacker')
 var csswring = require('csswring')
 
 gulp.task('css', function () {
-  var processors = [
-    autoprefixer('last 1 version').postcss
-  , mqpacker.processor
-  , csswring.postcss
-  ]
-  return gulp.src('./src/*.css')
-    .pipe(postcss(processors))
-    .pipe(gulp.dest('./dest'))
-})
+    var processors = [
+        autoprefixer('last 1 version').postcss,
+        mqpacker.processor,
+        csswring.postcss
+    ];
+    return gulp.src('./src/*.css')
+        .pipe(postcss(processors))
+        .pipe(gulp.dest('./dest'));
+});
 ```
 
 ## Source map support
@@ -29,10 +30,10 @@ gulp.task('css', function () {
 Source map is inlined by default, to extract map use together
 with [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps).
 
-```
+```js
 return gulp.src('./src/*.css')
-  .pipe(sourcemaps.init())
-  .pipe(postcss(processors))
-  .pipe(sourcemaps.write('.'))
-  .pipe(gulp.dest('./dest'))
+    .pipe(sourcemaps.init())
+    .pipe(postcss(processors))
+    .pipe(sourcemaps.write('.'))
+    .pipe(gulp.dest('./dest'));
 ```


### PR DESCRIPTION
1. Add description, why this plugin is better, that separated processors.
2. Add syntax highlight.
3. Format examples according most popular format.
