### PR TITLE
Fix relative imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var path = require('path')
+
 var through = require('through2')
 var postcss = require('postcss')
 var applySourceMap = require('vinyl-sourcemaps-apply')
@@ -34,7 +36,7 @@ module.exports = function (processors, options) {
     }
 
     if (file.base && file.path) {
-      opts.from = file.relative
+      opts.from = path.join(file.base, file.relative)
     } else {
       opts.from = file.path
     }


### PR DESCRIPTION
These changes make sure relative imports work with the postcss-import plugin without additional configuration. See postcss/postcss-import#10 for more information. I hope this doesn't break source maps.
