### PR TITLE
Added CSS next example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ gulp.task('css', function () {
 ```js
 var postcss = require('gulp-postcss');
 var autoprefixer = require('autoprefixer-core');
+var cssnext = require('cssnext');
 var opacity = function (css, opts) {
     css.eachDecl(function(decl) {
         if (decl.prop === 'opacity') {
@@ -47,7 +48,8 @@ var opacity = function (css, opts) {
 gulp.task('css', function () {
     var processors = [
         autoprefixer({browsers: ['last 1 version']}),
-        opacity
+        opacity,
+        cssnext()
     ];
     return gulp.src('./src/*.css')
         .pipe(postcss(processors))


### PR DESCRIPTION
Struggled to get an example of cssnext added because it needs to be called in the list of processors - since it is one of the most popular I thought it would be helpful to add to the docs.