### PR TITLE
Fix syntax error message for PostCSS 5.2 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = function (processors, options) {
     function handleError (error) {
       var errorOptions = { fileName: file.path, showStack: true }
       if (error.name === 'CssSyntaxError') {
-        error = error.message + error.showSourceCode()
+        error = error.message + '\n\n' + error.showSourceCode() + '\n'
         errorOptions.showStack = false
       }
       // Prevent stream’s unhandled exception from

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/postcss/gulp-postcss",
   "dependencies": {
     "gulp-util": "^3.0.7",
-    "postcss": "^5.0.14",
+    "postcss": "^5.2.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -243,7 +243,7 @@ describe('PostCSS Guidelines', function () {
 
     stream.on('error', function (error) {
       assert.equal(error.showStack, false)
-      assert.equal(error.message, 'message' + 'sourceCode')
+      assert.equal(error.message, 'message' + '\n\nsourceCode\n')
       cb()
     })
 


### PR DESCRIPTION
5.2 has not `\n` in `error.showSourceCode()` begging. Also I add some extra `\n` around code frame to have same style with webpack and Babel errors.

@w0rm hope you like Korea :)