### PR TITLE
Allow setting opts.from manually

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function (processors, options) {
       }
     }
 
-    opts.from = file.path
+    opts.from = opts.from || file.path
     opts.to = opts.to || file.path
 
     // Generate separate source map for gulp-sourcemap


### PR DESCRIPTION
I'd like to be able to manually set the `from` key, but it keeps getting overwritten. I don't really think this is a major change or heavily impacts or breaks any use cases, but it helps me if I want a consistent `from` that's very different from the file's path.