### PR TITLE
Test case fix for warnings

### DIFF
--- a/test.js
+++ b/test.js
@@ -115,7 +115,7 @@ it('should generate source maps', function (cb) {
 
   write.on('data', function (file) {
     assert.equal(file.sourceMap.mappings, 'AAAA,IAAI,aAAY,CAAZ,aAAY,CAAZ,aAAY,CAAZ,YAAY,EAAE')
-    assert(/sourceMappingURL=data:application\/json;base64/.test(file.contents.toString()))
+    assert(/sourceMappingURL=data:application\/json;(?:charset=\w+;)?base64/.test(file.contents.toString()))
     cb()
   })
 

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ var sourceMaps = require('gulp-sourcemaps')
 var postcss = require('./index')
 var proxyquire = require('proxyquire')
 var sinon = require('sinon')
+var path = require('path')
 
 it('should pass file when it isNull()', function (cb) {
   var stream = postcss([ doubler ])
@@ -261,7 +262,7 @@ describe('PostCSS Guidelines', function () {
     var stream = postcss([ doubler ])
     var cssPath = __dirname + '/src/fixture.css'
     function Warning (msg) {
-      this.toSting = function () {
+      this.toString = function () {
         return msg
       }
     }
@@ -275,7 +276,7 @@ describe('PostCSS Guidelines', function () {
     }))
 
     stream.on('data', function () {
-      gutil.log.calledWith('gulp-postcss:', '/src/fixture.css\nmsg1\nmsg2')
+      assert(gutil.log.calledWith('gulp-postcss:', 'src' +  path.sep + 'fixture.css\nmsg1\nmsg2'))
       cb()
     })
 


### PR DESCRIPTION
#97 Fix the test case: should display `result.warnings()` content