### PR TITLE
add `postcss.reporter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ gulp.task('css', function () {
 });
 ```
 
+## Report messages
+
+Report messages (warnings, etc.) registered by other PostCSS processors.
+
+
+```js
+return gulp.src('./src/*.css')
+    .pipe(postcss(processors))
+    .pipe(postcss.reporter(options))
+    .pipe(gulp.dest('./dest'));
+```
+Supports [postcss-reporter](https://www.npmjs.com/package/postcss-reporter) or [postcss-browser-reporter](https://www.npmjs.com/package/postcss-reporter) options.
+
 ## Source map support
 
 Source map is disabled by default, to extract map use together

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ gulp.task('css', function () {
 
 Report messages (warnings, etc.) registered by other PostCSS processors.
 
-
 ```js
 return gulp.src('./src/*.css')
     .pipe(postcss(processors))

--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ module.exports = function (processors, options) {
 
     function handleResult (result) {
       var map
-      var warnings = result.warnings().join('\n')
 
       file.contents = new Buffer(result.css)
 
@@ -64,9 +63,7 @@ module.exports = function (processors, options) {
         applySourceMap(file, map)
       }
 
-      if (warnings) {
-        gutil.log('gulp-postcss:', file.relative + '\n' + warnings)
-      }
+      file.postcss = result
 
       setImmediate(function () {
         cb(null, file)
@@ -89,4 +86,22 @@ module.exports = function (processors, options) {
   }
 
   return stream
+}
+
+module.exports.reporter = function(options) {
+  var isBrowser = options && options.selector || options.styles
+  var reporter = require(isBrowser ? 'postcss-browser-reporter' : 'postcss-reporter');
+  return new Stream.Transform({
+    objectMode: true,
+    transform: function(file, encoding, cb) {
+      var result = file.postcss
+      if (result) {
+        reporter(options)(result.root, result)
+        if (isBrowser) {
+          file.contents = new Buffer(result.css)
+        }
+      }
+      cb(null, file)
+    }
+  })
 }

--- a/index.js
+++ b/index.js
@@ -90,18 +90,18 @@ module.exports = function (processors, options) {
 
 module.exports.reporter = function(options) {
   var isBrowser = options && options.selector || options.styles
-  var reporter = require(isBrowser ? 'postcss-browser-reporter' : 'postcss-reporter');
-  return new Stream.Transform({
-    objectMode: true,
-    transform: function(file, encoding, cb) {
-      var result = file.postcss
-      if (result) {
-        reporter(options)(result.root, result)
-        if (isBrowser) {
-          file.contents = new Buffer(result.css)
-        }
+  var reporter = require(isBrowser ? 'postcss-browser-reporter' : 'postcss-reporter')(options);
+  var stream = new Stream.Transform({ objectMode: true })
+
+  stream._transform = function (file, encoding, cb) {
+    var result = file.postcss
+    if (result) {
+      reporter(result.root, result)
+      if (isBrowser) {
+        file.contents = new Buffer(result.css)
       }
-      cb(null, file)
     }
-  })
+    cb(null, file)
+  }
+  return stream
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "dependencies": {
     "gulp-util": "^3.0.7",
     "postcss": "^5.2.0",
+    "postcss-browser-reporter": "^0.5.0",
+    "postcss-reporter": "^1.4.1",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
```js
return gulp.src('./src/*.css')
    .pipe(postcss(processors))
    .pipe(postcss.reporter(options))
    .pipe(gulp.dest('./dest'));
```

-  add `postcss.reporter` give user a better message reporter.
-  add `file.postcss` let other gulp plugin to read result of `postcss`.
