### PR TITLE
Load options and plugins from postcss-load-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - iojs
-  - "stable"
-  - "0.12"
-  - "0.10"
+  - stable
+  - 6
+  - 4
+  - 0.12

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gulp-postcss [![Build Status](https://api.travis-ci.org/postcss/gulp-postcss.png)](https://travis-ci.org/postcss/gulp-postcss)
 
 [PostCSS](https://github.com/postcss/postcss) gulp plugin to pipe CSS through
-several processors, but parse CSS only once.
+several plugins, but parse CSS only once.
 
 ## Install
 
@@ -11,6 +11,23 @@ Install required [postcss plugins](https://www.npmjs.com/browse/keyword/postcss-
 
 ## Basic usage
 
+The configuration is loaded automatically from `postcss.config.js`
+as [described here](https://www.npmjs.com/package/postcss-load-config),
+so you don't have to specify any options.
+
+```js
+var postcss = require('gulp-postcss');
+var gulp = require('gulp');
+
+gulp.task('css', function () {
+    return gulp.src('./src/*.css')
+        .pipe(postcss())
+        .pipe(gulp.dest('./dest'));
+});
+```
+
+## Passing plugins directly
+
 ```js
 var postcss = require('gulp-postcss');
 var gulp = require('gulp');
@@ -18,12 +35,12 @@ var autoprefixer = require('autoprefixer');
 var cssnano = require('cssnano');
 
 gulp.task('css', function () {
-    var processors = [
+    var plugins = [
         autoprefixer({browsers: ['last 1 version']}),
-        cssnano(),
+        cssnano()
     ];
     return gulp.src('./src/*.css')
-        .pipe(postcss(processors))
+        .pipe(postcss(plugins))
         .pipe(gulp.dest('./dest'));
 });
 ```
@@ -41,9 +58,9 @@ var nested = require('postcss-nested');
 var scss = require('postcss-scss');
 
 gulp.task('default', function () {
-    var processors = [nested];
+    var plugins = [nested];
     return gulp.src('in.css')
-        .pipe(postcss(processors, {syntax: scss}))
+        .pipe(postcss(plugins, {syntax: scss}))
         .pipe(gulp.dest('out'));
 });
 ```
@@ -65,12 +82,12 @@ var opacity = function (css, opts) {
 };
 
 gulp.task('css', function () {
-    var processors = [
+    var plugins = [
         cssnext({browsers: ['last 1 version']}),
-        opacity,
+        opacity
     ];
     return gulp.src('./src/*.css')
-        .pipe(postcss(processors))
+        .pipe(postcss(plugins))
         .pipe(gulp.dest('./dest'));
 });
 ```
@@ -83,7 +100,7 @@ with [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps).
 ```js
 return gulp.src('./src/*.css')
     .pipe(sourcemaps.init())
-    .pipe(postcss(processors))
+    .pipe(postcss(plugins))
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('./dest'));
 ```
@@ -124,7 +141,7 @@ return gulp.src('./src/*.css')
 
 * 5.1.4
   * Simplified error handling
-  * Simplified postcss execution with object processors
+  * Simplified postcss execution with object plugins
 
 * 5.1.3 Updated travis banner
 
@@ -139,7 +156,7 @@ return gulp.src('./src/*.css')
   * Display `result.warnings()` content
 
 * 5.0.1
-  * Fix to support object processors
+  * Fix to support object plugins
 
 * 5.0.0
   * Use async API
@@ -173,7 +190,7 @@ return gulp.src('./src/*.css')
   * Improved README
 
 * 1.0.1
-  * Don't add source map comment if used with gulp-sourcemap
+  * Don't add source map comment if used with gulp-sourcemaps
 
 * 1.0.0
   * Initial release

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = withConfigLoader(function (loadConfig) {
       return handleError('Streams are not supported!')
     }
 
-    // Protect `from` and `map` if using gulp-sourcemap
+    // Protect `from` and `map` if using gulp-sourcemaps
     var isProtected = file.sourceMap
       ? { from: true, map: true }
       : {}
@@ -28,7 +28,7 @@ module.exports = withConfigLoader(function (loadConfig) {
     var options = {
       from: file.path
     , to: file.path
-      // Generate a separate source map for gulp-sourcemap
+      // Generate a separate source map for gulp-sourcemaps
     , map: file.sourceMap ? { annotation: false } : false
     }
 
@@ -47,7 +47,7 @@ module.exports = withConfigLoader(function (loadConfig) {
             gutil.log(
               'gulp-postcss:',
               file.relative + '\nCannot override ' + opt +
-              ' option, because it is required by gulp-sourcemap'
+              ' option, because it is required by gulp-sourcemaps'
             )
           }
         }

--- a/index.js
+++ b/index.js
@@ -110,11 +110,24 @@ function withConfigLoader(cb) {
       })
     } else {
       var postcssLoadConfig = require('postcss-load-config')
+      var contextOptions = plugins || {}
       return cb(function(file) {
-        return postcssLoadConfig({
-          file: file
-        , options: plugins
-        })
+        var configPath
+        if (contextOptions.config) {
+          if (path.isAbsolute(contextOptions.config)) {
+            configPath = contextOptions.config
+          } else {
+            configPath = path.join(file.base, contextOptions.config)
+          }
+        } else {
+          configPath = file.dirname
+        }
+        return postcssLoadConfig(
+          { file: file
+          , options: contextOptions
+          },
+          configPath
+        )
       })
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
   },
   "homepage": "https://github.com/postcss/gulp-postcss",
   "dependencies": {
-    "gulp-util": "^3.0.7",
-    "postcss": "^5.2.0",
-    "vinyl-sourcemaps-apply": "^0.2.0"
+    "gulp-util": "^3.0.8",
+    "postcss": "^5.2.10",
+    "postcss-load-config": "^1.1.0",
+    "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "devDependencies": {
-    "es6-promise": "^3.0.2",
-    "gulp-sourcemaps": "^1.5.1",
-    "mocha": "^2.2.5",
+    "es6-promise": "^3.3.1",
+    "gulp-sourcemaps": "^1.11.0",
+    "mocha": "^3.2.0",
     "proxyquire": "^1.7.4",
     "sinon": "^1.17.3"
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "devDependencies": {
-    "es6-promise": "^3.3.1",
     "gulp-sourcemaps": "^1.11.0",
     "mocha": "^3.2.0",
     "proxyquire": "^1.7.4",

--- a/test.js
+++ b/test.js
@@ -280,7 +280,7 @@ describe('PostCSS Guidelines', function () {
 
   })
 
-  it('should not override `from` and `map` if using source maps', function (cb) {
+  it('should not override `from` and `map` if using gulp-sourcemaps', function (cb) {
     var stream = postcss([ doubler ], { from: 'overriden', map: 'overriden' })
     var cssPath = __dirname + '/fixture.css'
     postcssStub.process.returns(Promise.resolve({
@@ -305,8 +305,8 @@ describe('PostCSS Guidelines', function () {
       assert.deepEqual(postcssStub.process.getCall(0).args[1].map, { annotation: false })
       var firstMessage = gutil.log.getCall(0).args[1]
       var secondMessage = gutil.log.getCall(1).args[1]
-      assert(firstMessage, '/fixture.css\nCannot override from option, because it is required by gulp-sourcemap')
-      assert(secondMessage, '/fixture.css\nCannot override map option, because it is required by gulp-sourcemap')
+      assert(firstMessage, '/fixture.css\nCannot override from option, because it is required by gulp-sourcemaps')
+      assert(secondMessage, '/fixture.css\nCannot override map option, because it is required by gulp-sourcemaps')
       cb()
     })
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,5 @@
 /* global it, afterEach, beforeEach, describe, Promise */
 
-require('es6-promise').polyfill()
 var assert = require('assert')
 var gutil = require('gulp-util')
 var sourceMaps = require('gulp-sourcemaps')


### PR DESCRIPTION
This fixes #92

If gulp-sourcemaps is used, `from` and `map` options cannot be overridden, so a warning will be displayed.

cc @ai @michael-ciniawsky 