### PR TITLE
Update postcss-load-config v1.1.0...1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "homepage": "https://github.com/postcss/gulp-postcss",
   "dependencies": {
     "gulp-util": "^3.0.8",
-    "postcss": "^5.2.10",
-    "postcss-load-config": "^1.1.0",
+    "postcss": "^5.2.12",
+    "postcss-load-config": "^1.2.0",
     "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
@woorm Just minor to allow using file extensions for `.postcssrc` files e.g `(.postcssrc.js|json|yaml)`