### PR TITLE
Bump PostCSS to 6.0.2 / Release 7.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ module.exports = function (ctx) {
 
 ## Changelog
 
+* 7.0.1
+  * Bump PostCSS to 6.0.2
+
 * 7.0.0
   * Bump PostCSS to 6.0
   * Smaller module size

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-postcss",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "PostCSS gulp plugin",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/postcss/gulp-postcss",
   "dependencies": {
     "gulp-util": "^3.0.8",
-    "postcss": "^6.0.0",
+    "postcss": "^6.0.2",
     "postcss-load-config": "^1.2.0",
     "vinyl-sourcemaps-apply": "^0.2.1"
   },


### PR DESCRIPTION
- Keeps `raws.before` on moving `Root` children to new `Root`.
- Fixes parser extensibility to use it in Safe Parser.