### PR TITLE
Update for the new Autoprefixer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ language: node_js
 node_js:
   - stable
   - 6
-  - 4
 after_success:
   - "npm run coveralls"

--- a/package.json
+++ b/package.json
@@ -39,19 +39,19 @@
   "homepage": "https://github.com/postcss/gulp-postcss",
   "dependencies": {
     "fancy-log": "^1.3.2",
-    "plugin-error": "^0.1.2",
-    "postcss": "^6.0.0",
-    "postcss-load-config": "^1.2.0",
+    "plugin-error": "^1.0.1",
+    "postcss": "^7.0.2",
+    "postcss-load-config": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "devDependencies": {
-    "coveralls": "^2.13.1",
-    "eslint": "^4.1.1",
+    "coveralls": "^3.0.2",
+    "eslint": "^5.3.0",
     "gulp-sourcemaps": "^2.6.0",
-    "mocha": "^3.4.2",
-    "nyc": "^11.0.3",
-    "proxyquire": "^1.8.0",
-    "sinon": "^2.3.5",
-    "vinyl": "^2.1.0"
+    "mocha": "^5.2.0",
+    "nyc": "^12.0.2",
+    "proxyquire": "^2.0.1",
+    "sinon": "^6.1.4",
+    "vinyl": "^2.2.0"
   }
 }


### PR DESCRIPTION
The new autoprefixer requires PostCSS 7, so the dependencies have been updated. During the test node 4 was removed, the PostCSS 7 works with Spread Operator, which causes errors with node 4.