### PR TITLE
No `eachDecl` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ gulp.task('default', function () {
 var postcss = require('gulp-postcss');
 var cssnext = require('postcss-cssnext');
 var opacity = function (css, opts) {
-    css.eachDecl(function(decl) {
+    css.walkDecls(function(decl) {
         if (decl.prop === 'opacity') {
             decl.parent.insertAfter(decl, {
                 prop: '-ms-filter',


### PR DESCRIPTION
I tried the custom processor example but to no avail. The problem, which was pointed out https://github.com/postcss/gulp-postcss/issues/139, was that there is no `eachDecl` method. However, there is a `walkDecls`, which I have used in the updated example.