### PR TITLE
Ensure options are passed to plugins when using postcss.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,10 @@ gulp.task('css', function () {
 ```
 
 ```js
+// postcss.config.js or .postcssrc.js
 module.exports = function (ctx) {
     var file = ctx.file;
-    var options = ctx.options;
+    var options = ctx;
     return {
         parser: file.extname === '.sss' ? : 'sugarss' : false,
         plugins: {

--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ gulp.task('default', function () {
 });
 ```
 
+If you are using a `postcss.config.js` file, you can pass PostCSS options as the first argument to gulp-postcss.
+
+This, for instance, will let PostCSS know what the final file destination path is, since it will be unaware of the path given to `gulp.dest()`:
+
+```js
+var gulp = require('gulp');
+var postcss = require('gulp-postcss');
+
+gulp.task('default', function () {
+    return gulp.src('in.scss')
+        .pipe(postcss({ to: 'out/in.css' }))
+        .pipe(gulp.dest('out'));
+});
+```
+
 ## Using a custom processor
 
 ```js

--- a/index.js
+++ b/index.js
@@ -127,6 +127,8 @@ function withConfigLoader(cb) {
         } else {
           configPath = file.dirname
         }
+        // @TODO: The options property is deprecated and should be removed in 10.0.0.
+        contextOptions.options = Object.assign({}, contextOptions)
         contextOptions.file = file
         return postcssLoadConfig(
           contextOptions,

--- a/index.js
+++ b/index.js
@@ -127,11 +127,9 @@ function withConfigLoader(cb) {
         } else {
           configPath = file.dirname
         }
+        contextOptions.file = file
         return postcssLoadConfig(
-          {
-            file: file,
-            options: contextOptions
-          },
+          contextOptions,
           configPath
         )
       })

--- a/test.js
+++ b/test.js
@@ -329,7 +329,7 @@ describe('PostCSS Guidelines', function () {
     stream.on('data', function () {
       assert.deepEqual(postcssLoadConfigStub.getCall(0).args[0], {
         file: file,
-        options: { to: 'initial' }
+        to: 'initial'
       })
       assert.equal(postcssStub.use.getCall(0).args[0], plugins)
       assert.equal(postcssStub.process.getCall(0).args[1].to, 'overriden')

--- a/test.js
+++ b/test.js
@@ -329,7 +329,8 @@ describe('PostCSS Guidelines', function () {
     stream.on('data', function () {
       assert.deepEqual(postcssLoadConfigStub.getCall(0).args[0], {
         file: file,
-        to: 'initial'
+        to: 'initial',
+        options: { to: 'initial' }
       })
       assert.equal(postcssStub.use.getCall(0).args[0], plugins)
       assert.equal(postcssStub.process.getCall(0).args[1].to, 'overriden')

--- a/test.js
+++ b/test.js
@@ -251,7 +251,7 @@ describe('PostCSS Guidelines', function () {
 
   it('should allow override of `to` processing option', function (cb) {
 
-    var stream = postcss([ doubler ], {to: 'overriden'})
+    var stream = postcss([ doubler ], {to: 'overridden'})
     postcssStub.process.returns(Promise.resolve({
       css: '',
       warnings: function () {
@@ -260,7 +260,7 @@ describe('PostCSS Guidelines', function () {
     }))
 
     stream.on('data', function () {
-      assert.equal(postcssStub.process.getCall(0).args[1].to, 'overriden')
+      assert.equal(postcssStub.process.getCall(0).args[1].to, 'overridden')
       cb()
     })
 
@@ -282,7 +282,7 @@ describe('PostCSS Guidelines', function () {
     var plugins = [ doubler ]
     var callback = sandbox.stub().returns({
       plugins: plugins,
-      options: { to: 'overriden' }
+      options: { to: 'overridden' }
     })
     var stream = postcss(callback)
 
@@ -296,7 +296,7 @@ describe('PostCSS Guidelines', function () {
     stream.on('data', function () {
       assert.equal(callback.getCall(0).args[0], file)
       assert.equal(postcssStub.use.getCall(0).args[0], plugins)
-      assert.equal(postcssStub.process.getCall(0).args[1].to, 'overriden')
+      assert.equal(postcssStub.process.getCall(0).args[1].to, 'overridden')
       cb()
     })
 
@@ -316,7 +316,7 @@ describe('PostCSS Guidelines', function () {
 
     postcssLoadConfigStub.returns(Promise.resolve({
       plugins: plugins,
-      options: { to: 'overriden' }
+      options: { to: 'overridden' }
     }))
 
     postcssStub.process.returns(Promise.resolve({
@@ -333,7 +333,7 @@ describe('PostCSS Guidelines', function () {
         options: { to: 'initial' }
       })
       assert.equal(postcssStub.use.getCall(0).args[0], plugins)
-      assert.equal(postcssStub.process.getCall(0).args[1].to, 'overriden')
+      assert.equal(postcssStub.process.getCall(0).args[1].to, 'overridden')
       cb()
     })
 
@@ -403,7 +403,7 @@ describe('PostCSS Guidelines', function () {
   })
 
   it('should not override `from` and `map` if using gulp-sourcemaps', function (cb) {
-    var stream = postcss([ doubler ], { from: 'overriden', map: 'overriden' })
+    var stream = postcss([ doubler ], { from: 'overridden', map: 'overridden' })
     var cssPath = __dirname + '/fixture.css'
     postcssStub.process.returns(Promise.resolve({
       css: '',


### PR DESCRIPTION
If a `postcss.config.js` is used (instead of passing a `plugins` array), the PostCSS options passed to gulp-postcss are ignored by all PostCSS plugins.

If you [look at the default export for `postcs-load-config`](https://github.com/postcss/postcss-load-config/blob/master/src/index.d.ts), you'll see:

```typescript
declare function postcssrc(ctx?: ConfigContext, path?: string, options?: CosmiconfigOptions): Promise<Result>;
export = postcssrc;
```
where `ConfigContext` is defined as:
```typescript
import { ProcessOptions } from "postcss";

// The full shape of the ConfigContext.
type ConfigContext = Context & ProcessOptionsPreload & RemainingProcessOptions;

// Additional context options that postcss-load-config understands.
interface Context {
    cwd?: string;
    env?: string;
}

interface ProcessOptionsPreload {
    parser?: string | ProcessOptions['parser'];
    stringifier?: string | ProcessOptions['stringifier'];
    syntax?: string | ProcessOptions['syntax'];
}

// The remaining ProcessOptions, sans the three above.
type RemainingProcessOptions =
    Pick<ProcessOptions, Exclude<keyof ProcessOptions, keyof ProcessOptionsPreload>>;
```

and [`ProcessOptions`, defined in PostCSS](https://github.com/postcss/postcss/blob/main/lib/postcss.d.ts#L289), contains these keys: `from`, `to`, `parser`, `stringifier`, `syntax`, `map`.

TLDR; the first argument to `postcssrc()` is a single object with `Context` and PostCSS' `ProcessOptions` merged together. 

But `gulp-postcss` is calling `postcssrc()` with `{ file: file, options: contextOptions }` as its first argument. I noticed 2 things with this:

`file` is not a part of `Context` or `ProcessOptions`. But I see that [`postcss-load-config`'s README](https://github.com/postcss/postcss-load-config) says:

> Most third-party integrations **add additional properties** (emphasis mine) to the ctx (e.g postcss-loader).

It looks like that is what gulp-postcss is doing with the additional `file` property. HOWEVER, the `ProcessOptions` are not passed as *a part of the ctx properties*; instead they are put into a sub-property,  `ctx.options`. That means **the options passed to `gulp-postcss` are ignored by all PostCSS plugins** since they are not where they are supposed to be.